### PR TITLE
ci: build and ship darwin/amd64 native binary via Rosetta

### DIFF
--- a/.github/workflows/homebrew-bump.yml
+++ b/.github/workflows/homebrew-bump.yml
@@ -37,6 +37,7 @@ jobs:
         id: sha
         run: |
           echo "darwin_arm64=$(grep 'floci-darwin-arm64' sha256sums.txt | awk '{print $1}')" >> "$GITHUB_OUTPUT"
+          echo "darwin_amd64=$(grep 'floci-darwin-amd64' sha256sums.txt | awk '{print $1}')" >> "$GITHUB_OUTPUT"
           echo "linux_amd64=$(grep 'floci-linux-amd64' sha256sums.txt | awk '{print $1}')" >> "$GITHUB_OUTPUT"
           echo "linux_arm64=$(grep 'floci-linux-arm64' sha256sums.txt | awk '{print $1}')" >> "$GITHUB_OUTPUT"
 
@@ -56,10 +57,12 @@ jobs:
          sed -i "s|releases/download/[^/]*/|releases/download/${VERSION}/|g" "$FORMULA"
          sed -i "s/{{VERSION}}/${VERSION}/g" "$FORMULA"
          sed -i "s/{{SHA256_DARWIN_ARM64}}/${{ steps.sha.outputs.darwin_arm64 }}/g" "$FORMULA"
+         sed -i "s/{{SHA256_DARWIN_AMD64}}/${{ steps.sha.outputs.darwin_amd64 }}/g" "$FORMULA"
          sed -i "s/{{SHA256_LINUX_AMD64}}/${{ steps.sha.outputs.linux_amd64 }}/g" "$FORMULA"
          sed -i "s/{{SHA256_LINUX_ARM64}}/${{ steps.sha.outputs.linux_arm64 }}/g" "$FORMULA"
 
          sed -i "/darwin-arm64/ { n; s/sha256 \".*\"/sha256 \"${{ steps.sha.outputs.darwin_arm64 }}\"/ }" "$FORMULA"
+         sed -i "/darwin-amd64/ { n; s/sha256 \".*\"/sha256 \"${{ steps.sha.outputs.darwin_amd64 }}\"/ }" "$FORMULA"
          sed -i "/linux-amd64/ { n; s/sha256 \".*\"/sha256 \"${{ steps.sha.outputs.linux_amd64 }}\"/ }" "$FORMULA"
          sed -i "/linux-arm64/ { n; s/sha256 \".*\"/sha256 \"${{ steps.sha.outputs.linux_arm64 }}\"/ }" "$FORMULA"
      

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,6 +73,45 @@ jobs:
           name: floci-darwin-arm64
           path: target/floci-darwin-arm64
 
+  build-darwin-amd64:
+    name: Build — darwin/amd64 (Rosetta)
+    # GraalVM native-image cannot cross-compile architectures, and GitHub's Intel
+    # macOS runners (macos-13) queue for hours and are being deprecated — a past
+    # release sat 9.5h on macos-13 before being cancelled. Instead we run an
+    # x86_64 GraalVM under Rosetta 2 on the reliable Apple Silicon runner.
+    # setup-graalvm has no arch override, so the x86_64 JDK is installed manually.
+    runs-on: macos-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rosetta 2
+        run: sudo softwareupdate --install-rosetta --agree-to-license
+
+      - name: Install x86_64 GraalVM
+        run: |
+          curl -fsSL -o "$RUNNER_TEMP/graalvm-x64.tar.gz" \
+            https://download.oracle.com/graalvm/25/latest/graalvm-jdk-25_macos-x64_bin.tar.gz
+          mkdir -p "$RUNNER_TEMP/graalvm-x64"
+          tar -xzf "$RUNNER_TEMP/graalvm-x64.tar.gz" -C "$RUNNER_TEMP/graalvm-x64" --strip-components 1
+          echo "JAVA_HOME=$RUNNER_TEMP/graalvm-x64/Contents/Home" >> "$GITHUB_ENV"
+          echo "$RUNNER_TEMP/graalvm-x64/Contents/Home/bin" >> "$GITHUB_PATH"
+
+      - name: Verify x86_64 toolchain
+        run: arch -x86_64 "$JAVA_HOME/bin/java" -XshowSettings:properties -version 2>&1 | grep 'os.arch'
+
+      - name: Build native binary (x86_64 under Rosetta)
+        run: arch -x86_64 mvn clean package -Pnative -DskipTests -B
+
+      - name: Verify binary is x86_64
+        run: file target/floci | grep -q x86_64
+
+      - run: mv target/floci target/floci-darwin-amd64
+      - uses: actions/upload-artifact@v4
+        with:
+          name: floci-darwin-amd64
+          path: target/floci-darwin-amd64
+
   build-windows-amd64:
     name: Build — windows/amd64
     runs-on: windows-latest
@@ -111,7 +150,7 @@ jobs:
 
   release:
     name: Create GitHub Release
-    needs: [build-linux-amd64, build-linux-arm64, build-darwin-arm64, build-windows-amd64, build-jar]
+    needs: [build-linux-amd64, build-linux-arm64, build-darwin-amd64, build-darwin-arm64, build-windows-amd64, build-jar]
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -159,6 +198,7 @@ jobs:
           files: |
             dist/floci-linux-amd64/floci-linux-amd64
             dist/floci-linux-arm64/floci-linux-arm64
+            dist/floci-darwin-amd64/floci-darwin-amd64
             dist/floci-darwin-arm64/floci-darwin-arm64
             dist/floci-windows-amd64/floci-windows-amd64.exe
             dist/floci-jar/floci.jar

--- a/.github/workflows/test-darwin-amd64.yml
+++ b/.github/workflows/test-darwin-amd64.yml
@@ -1,0 +1,49 @@
+name: Test — darwin/amd64 (Rosetta)
+
+# TEMPORARY: manual smoke test for the x86_64-under-Rosetta native build used by
+# release.yml's build-darwin-amd64 job. Trigger it from the Actions tab (or
+# `gh workflow run`) to validate the toolchain without cutting a tag/release.
+# Delete this file once the approach is confirmed working.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-darwin-amd64:
+    name: Build — darwin/amd64 (Rosetta)
+    runs-on: macos-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rosetta 2
+        run: sudo softwareupdate --install-rosetta --agree-to-license
+
+      - name: Install x86_64 GraalVM
+        run: |
+          curl -fsSL -o "$RUNNER_TEMP/graalvm-x64.tar.gz" \
+            https://download.oracle.com/graalvm/25/latest/graalvm-jdk-25_macos-x64_bin.tar.gz
+          mkdir -p "$RUNNER_TEMP/graalvm-x64"
+          tar -xzf "$RUNNER_TEMP/graalvm-x64.tar.gz" -C "$RUNNER_TEMP/graalvm-x64" --strip-components 1
+          echo "JAVA_HOME=$RUNNER_TEMP/graalvm-x64/Contents/Home" >> "$GITHUB_ENV"
+          echo "$RUNNER_TEMP/graalvm-x64/Contents/Home/bin" >> "$GITHUB_PATH"
+
+      - name: Verify x86_64 toolchain
+        run: |
+          arch -x86_64 "$JAVA_HOME/bin/java" -XshowSettings:properties -version 2>&1 | grep 'os.arch'
+          arch -x86_64 "$JAVA_HOME/bin/native-image" --version
+
+      - name: Build native binary (x86_64 under Rosetta)
+        run: arch -x86_64 mvn clean package -Pnative -DskipTests -B
+
+      - name: Verify binary is x86_64
+        run: file target/floci | tee /dev/stderr | grep -q x86_64
+
+      - run: mv target/floci target/floci-darwin-amd64
+      - uses: actions/upload-artifact@v4
+        with:
+          name: floci-darwin-amd64
+          path: target/floci-darwin-amd64

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ This project uses [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Release ships a `darwin/amd64` (Intel macOS) native binary again — built with an x86_64 GraalVM under Rosetta 2 on the Apple Silicon runner, avoiding the unreliable/queue-bound `macos-13` Intel runner that previously caused the target to be dropped (a past release sat 9.5h on `macos-13` before being cancelled). The Homebrew formula bump again wires the `darwin/amd64` SHA, so `brew install` and the install script resolve a real Intel binary instead of 404ing ([#2](https://github.com/floci-io/floci-cli/issues/2))
+
 ## [0.1.4] — 2026-06-02
 
 ### Fixed


### PR DESCRIPTION
## Summary

Restores the **darwin/amd64 (Intel macOS)** native binary, which had been dropped — leaving `brew install` and the install script with no Intel asset to fetch (404).

## Why the old approach failed
GraalVM native-image can't cross-compile architectures, and GitHub's Intel `macos-13` runners queue for hours and are being deprecated. A past release sat **9.5h** on `macos-13` before being cancelled.

## Approach
- New release job runs an **x86_64 GraalVM under Rosetta 2** on the reliable Apple Silicon runner to produce a genuine x86_64 binary (verified `file` is `x86_64` before upload).
- Re-wires `homebrew-bump.yml` to fill the `darwin/amd64` SHA so the formula resolves a real Intel binary.
- Adds a manually-triggered `test-darwin-amd64.yml` workflow to smoke-test the Rosetta build without cutting a release.

> Note: the Homebrew tap's `on_intel` block only becomes valid once a release actually ships `floci-darwin-amd64` — this PR + the next release tag deliver that.

Closes #2