### PR TITLE
fix(installer): retry transient downloads and stop false checksum errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ This project uses [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `install.sh` no longer reports a misleading "Checksum mismatch" when a download transiently fails. A failed `sha256sums.txt` fetch inside a command-substitution pipeline was masked by `set -e`, leaving the expected checksum empty and falsely flagging a mismatch against a correctly-downloaded binary. The installer now retries every download with backoff — an explicit loop (4 attempts by default, tunable via `FLOCI_DOWNLOAD_RETRIES`) that treats both transient HTTP errors and 0-byte responses as retryable, on top of `curl --retry` — fetches checksums to a file so download failures are caught, and emits distinct errors for "couldn't fetch checksum" vs. an actual mismatch. Adds `FLOCI_SKIP_CHECKSUM=1` to bypass verification (floci-io/floci#1236)
+
 ## [0.1.4] — 2026-06-02
 
 ### Fixed

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -6,6 +6,31 @@ VERSION="${FLOCI_CLI_VERSION:-latest}"
 INSTALL_DIR="${FLOCI_INSTALL_DIR:-/usr/local/bin}"
 BINARY="floci"
 REPO="floci-io/floci-cli"
+SKIP_CHECKSUM="${FLOCI_SKIP_CHECKSUM:-0}"
+DOWNLOAD_RETRIES="${FLOCI_DOWNLOAD_RETRIES:-4}"
+
+# Download $1 to $2, retrying on transient failures. GitHub's CDN intermittently
+# returns 5xx (e.g. 504) on release assets, and can hand back a 0-byte body, so
+# we wrap curl in our own loop with backoff: an empty file is treated as a
+# failure and retried. curl's own --retry handles mid-transfer hiccups; the
+# outer loop covers cases it doesn't and works uniformly across curl versions.
+download() {
+    _url="$1"
+    _out="$2"
+    _attempt=1
+    while :; do
+        if curl -fsSL --retry 2 --retry-delay 1 "$_url" -o "$_out" && [ -s "$_out" ]; then
+            return 0
+        fi
+        if [ "$_attempt" -ge "$DOWNLOAD_RETRIES" ]; then
+            return 1
+        fi
+        _delay=$((_attempt * 2))
+        echo "  download failed (attempt ${_attempt}/${DOWNLOAD_RETRIES}), retrying in ${_delay}s..." >&2
+        sleep "$_delay"
+        _attempt=$((_attempt + 1))
+    done
+}
 
 detect_platform() {
     OS=$(uname -s | tr '[:upper:]' '[:lower:]')
@@ -24,8 +49,20 @@ detect_platform() {
 }
 
 fetch_latest_version() {
-    curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
-        | grep '"tag_name"' | sed 's/.*"tag_name": "\(.*\)".*/\1/'
+    _tmp=$(mktemp)
+    if ! download "https://api.github.com/repos/${REPO}/releases/latest" "$_tmp"; then
+        rm -f "$_tmp"
+        echo "Error: could not reach GitHub to determine the latest version." >&2
+        echo "Check your connection, or pin a version with FLOCI_CLI_VERSION=<tag>." >&2
+        exit 1
+    fi
+    _version=$(grep '"tag_name"' "$_tmp" | sed 's/.*"tag_name": "\(.*\)".*/\1/')
+    rm -f "$_tmp"
+    if [ -z "$_version" ]; then
+        echo "Error: could not parse the latest version from the GitHub API response." >&2
+        exit 1
+    fi
+    echo "$_version"
 }
 
 main() {
@@ -40,17 +77,45 @@ main() {
     TMP=$(mktemp)
 
     echo "Downloading floci ${VERSION} for ${PLATFORM}..."
-    curl -fsSL "$DOWNLOAD_URL" -o "$TMP"
+    if ! download "$DOWNLOAD_URL" "$TMP"; then
+        rm -f "$TMP"
+        echo "Error: failed to download the Floci binary from:" >&2
+        echo "  $DOWNLOAD_URL" >&2
+        echo "GitHub may be returning a temporary error (e.g. HTTP 504). Please retry shortly." >&2
+        exit 1
+    fi
     chmod +x "$TMP"
 
     # Verify checksum if sha256sum is available
-    if command -v sha256sum >/dev/null 2>&1; then
+    if [ "$SKIP_CHECKSUM" != "1" ] && command -v sha256sum >/dev/null 2>&1; then
         SUMS_URL="https://github.com/${REPO}/releases/download/${VERSION}/sha256sums.txt"
-        EXPECTED=$(curl -fsSL "$SUMS_URL" | grep "floci-${PLATFORM}" | awk '{print $1}')
+        SUMS_TMP=$(mktemp)
+        # Fetch to a file so a failed download is caught here, not silently
+        # swallowed inside a pipeline (which would yield an empty expected sum
+        # and a misleading "checksum mismatch").
+        if ! download "$SUMS_URL" "$SUMS_TMP"; then
+            rm -f "$TMP" "$SUMS_TMP"
+            echo "Error: failed to download checksums from:" >&2
+            echo "  $SUMS_URL" >&2
+            echo "Cannot verify the binary's integrity. Please retry, or set" >&2
+            echo "FLOCI_SKIP_CHECKSUM=1 to install without verification." >&2
+            exit 1
+        fi
+        EXPECTED=$(grep "floci-${PLATFORM}\$" "$SUMS_TMP" | awk '{print $1}')
+        rm -f "$SUMS_TMP"
+        if [ -z "$EXPECTED" ]; then
+            rm -f "$TMP"
+            echo "Error: no checksum entry for floci-${PLATFORM} in sha256sums.txt." >&2
+            echo "Please report this at https://github.com/${REPO}/issues." >&2
+            exit 1
+        fi
         ACTUAL=$(sha256sum "$TMP" | awk '{print $1}')
         if [ "$EXPECTED" != "$ACTUAL" ]; then
-            echo "Checksum mismatch! Expected: $EXPECTED  Got: $ACTUAL" >&2
             rm -f "$TMP"
+            echo "Checksum mismatch for floci-${PLATFORM} — the download may be corrupted." >&2
+            echo "  expected: $EXPECTED" >&2
+            echo "  actual:   $ACTUAL" >&2
+            echo "Please retry the install." >&2
             exit 1
         fi
         echo "Checksum verified."


### PR DESCRIPTION
## Summary

Fixes the misleading `Checksum mismatch! Expected:  Got: …` failure reported when the installer hits a transient GitHub CDN error (e.g. HTTP 504).

## Root cause
A failed `sha256sums.txt` fetch lived inside a command-substitution pipeline (`EXPECTED=$(curl … | grep … | awk …)`). Even under `set -e`, the pipeline's exit status is `awk`'s (success), so the curl failure was swallowed, `EXPECTED` became empty, and the script compared `"" != "<real hash>"` → a phantom mismatch on a perfectly valid binary. (Confirmed: the reporter's `Got:` hash matches the published `floci-linux-amd64` checksum exactly.)

## Fix
- `download()` helper with explicit **retry + backoff** (4 attempts, tunable via `FLOCI_DOWNLOAD_RETRIES`), treating both transient HTTP errors and 0-byte responses as retryable, on top of `curl --retry`.
- Checksums fetched to a file so a failed download is caught, not masked.
- Distinct errors for *couldn't fetch checksum* vs. *actual mismatch*.
- `FLOCI_SKIP_CHECKSUM=1` escape hatch.

## Testing
End-to-end against the real 0.1.4 release: happy path (checksum verified + installs), bad download (clean error, no false mismatch), checksum-fetch 504 (clear error), and skip-checksum all behave correctly.

Fixes floci-io/floci#1236