### PR TITLE
fix(doctor): make docker.daemon check work under Podman

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ This project uses [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `floci doctor`'s `docker.daemon` check reported "Docker daemon not reachable" under Podman even when the daemon was clearly up (container running, endpoint reachable). The probe used `docker info --format '{{.ServerVersion}}'`, a Docker-only template field that errors under `podman info`. It now checks daemon reachability by exit code alone (`docker info` / `podman info` exit 0 when reachable), with output discarded to avoid a pipe-buffer deadlock
+
 ## [0.1.5] — 2026-06-10
 
 ### Added

--- a/src/main/java/io/floci/cli/docker/DockerClient.java
+++ b/src/main/java/io/floci/cli/docker/DockerClient.java
@@ -30,8 +30,16 @@ public class DockerClient {
 
     public boolean isDaemonReachable() {
         try {
-            int code = runProcess("docker", "info", "--format", "{{.ServerVersion}}").waitFor();
-            return code == 0;
+            // Probe connectivity by exit code only. `docker info` / `podman info`
+            // exit 0 when the daemon (or DOCKER_HOST socket) is reachable. Avoid a
+            // Docker-only template field like {{.ServerVersion}}, which errors under
+            // Podman and yields a false "daemon not reachable". Output is discarded
+            // so the unread pipe can't fill and deadlock waitFor().
+            Process p = new ProcessBuilder("docker", "info")
+                    .redirectOutput(ProcessBuilder.Redirect.DISCARD)
+                    .redirectError(ProcessBuilder.Redirect.DISCARD)
+                    .start();
+            return p.waitFor() == 0;
         } catch (Exception e) {
             return false;
         }


### PR DESCRIPTION
## Summary

`floci doctor`'s **`docker.daemon`** check reported *"Docker daemon not reachable"* under Podman even when the daemon was clearly up — the same run showed `container.running`, `image.present`, and `endpoint.reachable` all passing, and `docker.socket` correctly resolving the `DOCKER_HOST` Podman socket.

```
✗ docker.daemon    Docker daemon not reachable
                   Fix: Start Docker: sudo systemctl start docker
✓ docker.socket    /run/user/100033/podman/podman.sock accessible
✓ container.running  Container 'floci' is running
✓ endpoint.reachable http://localhost:4566 is reachable
```

## Root cause

`isDaemonReachable()` probed with `docker info --format '{{.ServerVersion}}'`. `.ServerVersion` is a **Docker-only** `info` template field; under the `podman-docker` shim, `podman info` has no such field, so the template **errors and exits non-zero** → false "not reachable". (The reported "Docker 5.8.2" is Podman's version, confirming the shim.)

## Fix

Probe reachability by **exit code only** — `docker info` / `podman info` exit `0` when the daemon (or `DOCKER_HOST` socket) is reachable, non-zero when not — with no schema dependency. Output is discarded so the unread pipe can't fill and deadlock `waitFor()`.

```java
Process p = new ProcessBuilder("docker", "info")
        .redirectOutput(ProcessBuilder.Redirect.DISCARD)
        .redirectError(ProcessBuilder.Redirect.DISCARD)
        .start();
return p.waitFor() == 0;
```

## Testing

`mvn test` — 33 passing. (Daemon reachability is integration-only; no unit test added.)

## Follow-up (not in this PR)

Cosmetic Podman gaps remain: `docker.installed`/`docker.version` label Podman as "Docker" (and the `<20.10` warning is meaningless for Podman), and fix hints say "Docker Desktop"/"systemctl start docker". Worth a separate Podman-awareness enhancement.