### PR TITLE
fix(start): mount host persistent path to /app/data in container

### DIFF
--- a/src/main/java/io/floci/cli/commands/StartCommand.java
+++ b/src/main/java/io/floci/cli/commands/StartCommand.java
@@ -83,7 +83,7 @@ public class StartCommand implements Callable<Integer> {
         args.addAll(List.of("-p", port + ":4566"));
         args.addAll(DockerClient.dockerSocketRunArgs());
         if (persistDir != null) {
-            args.addAll(List.of("-v", persistDir + ":/var/lib/floci"));
+            args.addAll(List.of("-v", persistDir + ":/app/data"));
         }
         if (services != null && !services.isBlank()) {
             args.addAll(List.of("-e", "FLOCI_SERVICES=" + services));


### PR DESCRIPTION
This PR updates the CLI to mount the host persistent path to '/app/data' inside the container instead of '/var/lib/floci', aligning with the default storage directory in the emulator as suggested in floci-io/floci#1470.

Closes https://github.com/floci-io/floci/issues/1447