### PR TITLE
fix(start): enable persistent storage mode when --persist is set

### DIFF
--- a/src/main/java/io/floci/cli/commands/StartCommand.java
+++ b/src/main/java/io/floci/cli/commands/StartCommand.java
@@ -84,6 +84,9 @@ public class StartCommand implements Callable<Integer> {
         args.addAll(DockerClient.dockerSocketRunArgs());
         if (persistDir != null) {
             args.addAll(List.of("-v", persistDir + ":/app/data"));
+            // The server defaults to in-memory storage; enable persistent mode so
+            // state is actually written to the mounted directory and survives restarts.
+            args.addAll(List.of("-e", "FLOCI_STORAGE_MODE=persistent"));
         }
         if (services != null && !services.isBlank()) {
             args.addAll(List.of("-e", "FLOCI_SERVICES=" + services));

--- a/src/main/java/io/floci/cli/commands/az/AzStartCommand.java
+++ b/src/main/java/io/floci/cli/commands/az/AzStartCommand.java
@@ -79,6 +79,9 @@ public class AzStartCommand implements Callable<Integer> {
         args.addAll(DockerClient.dockerSocketRunArgs());
         if (persistDir != null) {
             args.addAll(List.of("-v", persistDir + ":/app/data"));
+            // The server defaults to in-memory storage; enable persistent mode so
+            // state is actually written to the mounted directory and survives restarts.
+            args.addAll(List.of("-e", "FLOCI_AZ_STORAGE_MODE=persistent"));
         }
         if (services != null && !services.isBlank()) {
             args.addAll(List.of("-e", "FLOCI_AZ_SERVICES=" + services));

--- a/src/main/java/io/floci/cli/commands/gcp/GcpStartCommand.java
+++ b/src/main/java/io/floci/cli/commands/gcp/GcpStartCommand.java
@@ -79,6 +79,9 @@ public class GcpStartCommand implements Callable<Integer> {
         args.addAll(DockerClient.dockerSocketRunArgs());
         if (persistDir != null) {
             args.addAll(List.of("-v", persistDir + ":/app/data"));
+            // The server defaults to in-memory storage; enable persistent mode so
+            // state is actually written to the mounted directory and survives restarts.
+            args.addAll(List.of("-e", "FLOCI_GCP_STORAGE_MODE=persistent"));
         }
         if (services != null && !services.isBlank()) {
             args.addAll(List.of("-e", "FLOCI_GCP_SERVICES=" + services));


### PR DESCRIPTION
## Problem

`floci start --persist <dir>` did not actually persist anything — emulator state was lost on every restart.

The `--persist` flag only bind-mounted the host directory to `/app/data`, but the server defaults to `FLOCI_STORAGE_MODE=memory` (see [storage docs](https://floci.io/floci/configuration/storage/)). In memory mode the server never writes to the mounted directory, so the mount was effectively a no-op.

## Fix

When `--persist` is provided, also set the storage mode env var so state is written to the mounted host directory. Each cloud uses its own prefix (confirmed from the actual image env defaults):

| Command | Variable added |
|---|---|
| `StartCommand` (AWS) | `FLOCI_STORAGE_MODE=persistent` |
| `GcpStartCommand` | `FLOCI_GCP_STORAGE_MODE=persistent` |
| `AzStartCommand` | `FLOCI_AZ_STORAGE_MODE=persistent` |

## Verification

- All 33 unit tests pass (`mvn test`).
- End-to-end through the real CLI: created an S3 bucket + object and a DynamoDB table + item, then ran `stop --remove` followed by `start --persist <same dir>`. The bucket, object content, and DynamoDB item **all survived** the restart. Confirmed the container receives `FLOCI_STORAGE_MODE=persistent`.

## Notes

This builds on #8 (which fixed the mount target to `/app/data`); that fix mounted the correct path but persistence still required the storage mode to be enabled.